### PR TITLE
Исправление метода getPaymentList и актуализация README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ const client = new ClientService({/* options */});
 | `privateKey` | `string` | Ваш приватный ключ |
 | `publicId` | `string` | Ваш публичный ключ |
 | `org.taxationSystem` | `TaxationSystem` | Система налогооблажения |
-| `org.vat` | `VAT` | НДС |
 | `org.inn` | `number` | ИНН |
 
 ## ClientApi
@@ -70,6 +69,12 @@ const client = new ClientService({/* options */});
 | getPayment | Просмотр информации об операции | https://developers.cloudpayments.ru/#prosmotr-tranzaktsii |
 | findPaymentByInvoiceId | Проверка статуса платежа | https://developers.cloudpayments.ru/#proverka-statusa-platezha |
 | getPaymentsList | Выгрузка списка транзакций | https://developers.cloudpayments.ru/#vygruzka-spiska-tranzaktsiy |
+| createOrder | Создание счета для отправки по почте | https://developers.cloudpayments.ru/#sozdanie-scheta-dlya-otpravki-po-pochte |
+| createSubscription | Создание подписки на рекуррентные платежи | https://developers.cloudpayments.ru/#sozdanie-podpiski-na-rekurrentnye-platezhi |
+| updateSubscription | Изменение подписки на рекуррентные платежи | https://developers.cloudpayments.ru/#izmenenie-podpiski-na-rekurrentnye-platezhi |
+| cancelSubscription | Отмена подписки на рекуррентные платежи | https://developers.cloudpayments.ru/#izmenenie-podpiski-na-rekurrentnye-platezhi |
+| getSubscription | Запрос информации о подписке | https://developers.cloudpayments.ru/#zapros-informatsii-o-podpiske |
+| getSubscriptionsList | Поиск подписок | https://developers.cloudpayments.ru/#poisk-podpisok |
  
 
 ## ReceiptApi

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const client = new ClientService({/* options */});
 | voidPayment | Отмена оплаты | https://cloudpayments.ru/Docs/Api#void |
 | getPayment | Просмотр информации об операции | https://cloudpayments.ru/Docs/Api#get |
 | findPaymentByInvoiceId | Проверка статуса платежа | https://cloudpayments.ru/Docs/Api#find |
-| getPaymentList | Выгрузка списка транзакций | https://cloudpayments.ru/Docs/Api#list |
+| getPaymentsList | Выгрузка списка транзакций | https://cloudpayments.ru/Docs/Api#list |
  
 
 ## ReceiptApi

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CloudPayments
 
 Библиотека для работы с API и обработки уведомлений от платежного
-сервиса [CloudPayments](https://cloudpayments.ru/Docs/Api).
+сервиса [CloudPayments](https://developers.cloudpayments.ru/#api).
 
 Все примеры приведены по стандарту es7. Версия поддерживаемой
 платформы Node.js 6 и выше.
@@ -33,9 +33,9 @@ const client = new ClientService({/* options */});
 
 | Method | Options | Return | Description |
 |---|---|---|---|
-| `getClientApi` |  | `ClientApi` | Возвращает экземпляр класса `ClientApi` для работы со стандартным [API](https://cloudpayments.ru/Docs/Api) |
-| `getReceiptApi` | | `ReceiptApi` | Возвращает экземпляр класса `ReceiptApi` для работы с [API кассы](https://cloudpayments.ru/docs/api/kassa) |
-| `getNotificationHandlers` | | `NotificationHandlers` | Возвращает экземпляр класса `ClientHandlers` для обработки [уведомлений](https://cloudpayments.ru/Docs/Notifications) |
+| `getClientApi` |  | `ClientApi` | Возвращает экземпляр класса `ClientApi` для работы со стандартным [API](https://developers.cloudpayments.ru/#api) |
+| `getReceiptApi` | | `ReceiptApi` | Возвращает экземпляр класса `ReceiptApi` для работы с [API кассы](https://developers.cloudkassir.ru/#api-kassy) |
+| `getNotificationHandlers` | | `NotificationHandlers` | Возвращает экземпляр класса `ClientHandlers` для обработки [уведомлений](https://developers.cloudpayments.ru/#uvedomleniya) |
 | `createClientApi` | `ClientOptions` | `ClientApi` | Создает отдельный экземпляр класса `ClientApi` |
 | `createReceiptApi` | `ClientOptions` | `ReceiptApi` | Создает отдельный экземпляр класса `ReceiptApi` |
 | `createNotificationHandlers` | `ClientOptions` | `NotificationHandlers` | Создает отдельный экземпляр класса `NotificationHandlers` |
@@ -59,17 +59,17 @@ const client = new ClientService({/* options */});
 
 | Метод | Описание | Документация |
 |-------|----------|--------------|
-| chargeCryptogramPayment | Оплата по криптограмме | https://cloudpayments.ru/Docs/Api#payWithCrypto |
-| authorizeCryptogramPayment | Оплата по криптограмме (преавторизация) | https://cloudpayments.ru/Docs/Api#payWithCrypto |
-| chargeTokenPayment | Оплата по токену | https://cloudpayments.ru/Docs/Api#payWithToken |
-| authorizeTokenPayment | Оплата по токену (преавторизация) | https://cloudpayments.ru/Docs/Api#payWithToken |
-| confirm3DSPayment | Обработка 3-D Secure | https://cloudpayments.ru/Docs/Api#3ds |
-| confirmPayment | Подтверждение оплаты | https://cloudpayments.ru/Docs/Api#confirm |
-| refundPayment | Возврат денег | https://cloudpayments.ru/Docs/Api#refund |
-| voidPayment | Отмена оплаты | https://cloudpayments.ru/Docs/Api#void |
-| getPayment | Просмотр информации об операции | https://cloudpayments.ru/Docs/Api#get |
-| findPaymentByInvoiceId | Проверка статуса платежа | https://cloudpayments.ru/Docs/Api#find |
-| getPaymentsList | Выгрузка списка транзакций | https://cloudpayments.ru/Docs/Api#list |
+| chargeCryptogramPayment | Оплата по криптограмме | https://developers.cloudpayments.ru/#oplata-po-kriptogramme |
+| authorizeCryptogramPayment | Оплата по криптограмме (преавторизация) | https://developers.cloudpayments.ru/#oplata-po-kriptogramme |
+| chargeTokenPayment | Оплата по токену | https://developers.cloudpayments.ru/#oplata-po-tokenu-rekarring |
+| authorizeTokenPayment | Оплата по токену (преавторизация) | https://developers.cloudpayments.ru/#oplata-po-tokenu-rekarring |
+| confirm3DSPayment | Обработка 3-D Secure | https://developers.cloudpayments.ru/#obrabotka-3-d-secure |
+| confirmPayment | Подтверждение оплаты | https://developers.cloudpayments.ru/#podtverzhdenie-oplaty |
+| refundPayment | Возврат денег | https://developers.cloudpayments.ru/#vozvrat-deneg |
+| voidPayment | Отмена оплаты | https://developers.cloudpayments.ru/#otmena-oplaty |
+| getPayment | Просмотр информации об операции | https://developers.cloudpayments.ru/#prosmotr-tranzaktsii |
+| findPaymentByInvoiceId | Проверка статуса платежа | https://developers.cloudpayments.ru/#proverka-statusa-platezha |
+| getPaymentsList | Выгрузка списка транзакций | https://developers.cloudpayments.ru/#vygruzka-spiska-tranzaktsiy |
  
 
 ## ReceiptApi
@@ -139,28 +139,28 @@ const server = createServer(async (req, res) => {
 
 | Method | Arguments | Return | Description |
 |---|---|---|---|
-| `createIncomeReceipt` | `ReceiptTypes`, `Receipt` | `Response<{}>` | Отправляет запрос на [создание чека](https://cloudpayments.ru/docs/api/kassa#receipt) |
+| `createReceipt` | `ReceiptTypes`, `Receipt` | `Response<{}>` | Отправляет запрос на [создание чека](https://developers.cloudkassir.ru/#formirovanie-kassovogo-cheka) |
 
 #### Receipt
 
-Смотрите [Receipt](src/ReceiptApi/Receipt.d.ts)
+Смотрите [Receipt](src/ReceiptApi.ts)
 
 ## Handlers
 
 В библиотеку `cloudpayments` встроен механизм обработки 
-уведомлений о платежах (смотрите [документацию](https://cloudpayments.ru/Docs/Notifications)). 
+уведомлений о платежах (смотрите [документацию](https://developers.cloudpayments.ru/#uvedomleniya)). 
 
 Список доступных методов для обработки уведомлений:
 
 | Метод | Параметры запроса | Ссылка на описание |
 |---|---|---|
-| `handleCheckRequest` | [CheckNotification](src/Api/notifications.d.ts) | https://cloudpayments.ru/Docs/Notifications#check |
-| `handlePayRequest` | [PayNotification](src/Api/notifications.d.ts) | https://cloudpayments.ru/Docs/Notifications#pay |
-| `handleFailRequest` | [FailNotification](src/Api/notifications.d.ts) | https://cloudpayments.ru/Docs/Notifications#fail |
-| `handleRecurrentRequest` | [RecurrentNotification](src/Api/notifications.d.ts) | https://cloudpayments.ru/Docs/Notifications#recurrent |
-| `handleRefundRequest` | [RefundNotification](src/Api/notifications.d.ts) | https://cloudpayments.ru/Docs/Notifications#refund |
-| `handleReceiptRequest` | [ReceiptNotification](src/Api/notifications.d.ts) | https://cloudpayments.ru/Docs/Notifications#receipt |
-| `handleConfirmRequest` | [ConfirmNotification](src/Api/notifications.d.ts) | https://cloudpayments.ru/Docs/Notifications#confirm |
+| `handleCheckRequest` | [CheckNotification](src/Api/notification.ts) | https://developers.cloudpayments.ru/#check |
+| `handlePayRequest` | [PayNotification](src/Api/notification.ts) | https://developers.cloudpayments.ru/#pay |
+| `handleFailRequest` | [FailNotification](src/Api/notification.ts) | https://developers.cloudpayments.ru/#fail |
+| `handleRecurrentRequest` | [RecurrentNotification](src/Api/notification.ts) | https://developers.cloudpayments.ru/#recurrent |
+| `handleRefundRequest` | [RefundNotification](src/Api/notification.ts) | https://developers.cloudpayments.ru/#refund |
+| `handleReceiptRequest` | [ReceiptNotification](src/Api/notification.ts) | https://developers.cloudpayments.ru/#receipt |
+| `handleConfirmRequest` | [ConfirmNotification](src/Api/notification.ts) | https://developers.cloudpayments.ru/#confirm |
 
 Пример использования:
 

--- a/src/ClientApi.ts
+++ b/src/ClientApi.ts
@@ -128,7 +128,7 @@ export class ClientApi extends ClientRequestAbstract {
      * @param {{Date: string | Date, TimeZone: string}} data
      * @returns {Promise<Response<PaymentHistoryResponse>>}
      */
-    public async getPaymentList(data: BaseRequest & { Date: string | Date, TimeZone?: string }) {
+    public async getPaymentsList(data: BaseRequest & { Date: string | Date, TimeZone?: string }) {
         return this.call<PaymentHistoryResponse>("/payments/list", data);
     }
 

--- a/src/ClientApi.ts
+++ b/src/ClientApi.ts
@@ -125,10 +125,10 @@ export class ClientApi extends ClientRequestAbstract {
     /**
      * Get a filtered payment list
      *
-     * @param {{Date: number, TimeZone: string}} data
+     * @param {{Date: string | Date, TimeZone: string}} data
      * @returns {Promise<Response<PaymentHistoryResponse>>}
      */
-    public async getPaymentList(data: BaseRequest & { Date: number, TimeZone?: string }) {
+    public async getPaymentList(data: BaseRequest & { Date: string | Date, TimeZone?: string }) {
         return this.call<PaymentHistoryResponse>("/payments/list", data);
     }
 

--- a/src/ClientApi.ts
+++ b/src/ClientApi.ts
@@ -129,7 +129,7 @@ export class ClientApi extends ClientRequestAbstract {
      * @returns {Promise<Response<PaymentHistoryResponse>>}
      */
     public async getPaymentList(data: BaseRequest & { Date: number, TimeZone?: string }) {
-        return this.call<PaymentHistoryResponse>("/payments/get", data);
+        return this.call<PaymentHistoryResponse>("/payments/list", data);
     }
 
     /**


### PR DESCRIPTION
Привет!

Я начал пользоваться библиотекой и заметил пару несостыковок:

1. Метод `getPaymentList` обращался к `/payments/get` вместо `/payments/list` (как сказано [в документации](https://developers.cloudpayments.ru/#vygruzka-spiska-tranzaktsiy)). Исправил это.

2. Тот же метод почему-то был описан как принимающий параметр `Date` типа `number`, однако там же [в документации](https://developers.cloudpayments.ru/#vygruzka-spiska-tranzaktsiy) сказано, что он должен быть типа `Date`. Я указал `Date` и `string` на случай, если кто-то руками захочет указать дату (проверил и с `new Date()`, работает из-за приведения JS-даты к строке нужного формата).

3. Странно, что метод вообще назывался `getPaymentList`, когда рядом есть `getSubscriptionsList`. Переименовал в `getPaymentsList` (Payment**s** вместо Payment). Не уверен, что это правильная правка, т. к. может что-то сломать у тех, кто зависит от библиотеки. Могу откатить.

4. Пока разбирался, что к чему, понял, что ссылки на документацию в README неактуальные, потому обновил их.

5. Пока писал п. 3 понял, что некоторое количество методов не описаны в README, потому добавил их туда.

Заодно у меня вопрос: метод `findPaymentByInvoiceId` называется странно. В остальных методах не указано bySmth, а тут указано. Может быть стоит его переименовать? Не стал этого делать, т. к. как и в п. 3 переживаю, что это может кому-то что-то сломать. Похожий вопрос про `getSubscriptionsList`, он вроде как find, а не get.

Энивэй, буду рад, если что-то из этого можно смержить и выкатить новую версию в npm (как минимум фикс метода), чтобы я мог использовать у себя библиотеку вместо своего форка :-)